### PR TITLE
Progress Bar Exercise V1

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -4,6 +4,7 @@
 @import "../shared_styles/general.scss";
 @import "../exercise/Exercise.scss";
 @import "../components/ProgressBar.scss";
+@import "../components/SimulateProgress.scss";
 
 .App {
   .exercise-index {

--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -3,6 +3,7 @@
 @import "../shared_styles/typography.scss";
 @import "../shared_styles/general.scss";
 @import "../exercise/Exercise.scss";
+@import "../components/ProgressBar.scss";
 
 .App {
   .exercise-index {

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const ProgressBar = ({ progress }) => (
+  <div className="progress-bar">
+    <div style={{ width: progress + '%' }} className="progress-bar__progress"></div>
+  </div>
+);
+
+export default ProgressBar;

--- a/src/components/ProgressBar.scss
+++ b/src/components/ProgressBar.scss
@@ -1,0 +1,13 @@
+.progress-bar {
+  background-color: $gray-lighter;
+  border-radius: 4px;
+  height: 6px;
+  width: 100%;
+
+  .progress-bar__progress {
+    background: linear-gradient(to left, $red, $sunset);
+    border-radius: 4px;
+    height: 100%;
+    transition: width 0.6s ease-out;
+  }
+}

--- a/src/components/ProgressBar.scss
+++ b/src/components/ProgressBar.scss
@@ -8,6 +8,6 @@
     background: linear-gradient(to left, $red, $sunset);
     border-radius: 4px;
     height: 100%;
-    transition: width 0.6s ease-out;
+    transition: width 0.3s linear;
   }
 }

--- a/src/components/SimulateProgress.js
+++ b/src/components/SimulateProgress.js
@@ -43,8 +43,13 @@ const SimulateProgressBar = () => {
       setTimeout(() => {
         clearInterval(interval);
         setLoading(LOADING_STATE.NOT_STARTED);
-        setProgress(0);
       }, [SECONDS_SHOWN_AFTER_LOADED * 1000]);
+
+      // set progress to 0 after progress bar has faded out
+      setTimeout(
+        () => setProgress(0),
+        [SECONDS_SHOWN_AFTER_LOADED * 1000 + 1000]
+      );
     }
 
     return () => clearInterval(interval);
@@ -94,7 +99,9 @@ const SimulateProgressBar = () => {
         </div>
       </div>
 
-      {isLoading ? <ProgressBar progress={progress} /> : null}
+      <div className={!isLoading ? "fade-out" : ""}>
+        <ProgressBar progress={progress} />
+      </div>
 
       {loading === LOADING_STATE.COMPLETE && (
         <i>progress bar will disappear in 3 seconds</i>

--- a/src/components/SimulateProgress.js
+++ b/src/components/SimulateProgress.js
@@ -19,7 +19,8 @@ const SimulateProgressBar = () => {
 
   // progress bar starts at width of 0% and takes 15 seconds to reach 90%
   // width-increase/second: 90% / 15sec = 6% / sec
-  const progressIncrement = HANGING_BREAKPOINT / seconds;
+  // diving by 10 on both progressIncrement and interval for smoother animation
+  const progressIncrement = HANGING_BREAKPOINT / seconds / 10;
 
   useEffect(() => {
     if (loading === LOADING_STATE.LOADING) {
@@ -33,7 +34,7 @@ const SimulateProgressBar = () => {
               ? prev + progressIncrement
               : HANGING_BREAKPOINT
           ),
-        1000
+        1000 / 10
       );
     }
 

--- a/src/components/SimulateProgress.js
+++ b/src/components/SimulateProgress.js
@@ -1,0 +1,106 @@
+import React, { useEffect, useRef, useState } from "react";
+import ProgressBar from "./ProgressBar";
+
+const INITIAL_LOADING_TIME = 1;
+const HANGING_BREAKPOINT = 90;
+const SECONDS_SHOWN_AFTER_LOADED = 3;
+
+const LOADING_STATE = {
+  NOT_STARTED: "NOT_STARTED",
+  LOADING: "LOADING",
+  COMPLETE: "COMPLETE",
+};
+
+const SimulateProgressBar = () => {
+  let interval = useRef(null);
+  const [seconds, setSeconds] = useState(INITIAL_LOADING_TIME);
+  const [progress, setProgress] = useState(0);
+  const [loading, setLoading] = useState(LOADING_STATE.NOT_STARTED);
+
+  // progress bar starts at width of 0% and takes 15 seconds to reach 90%
+  // width-increase/second: 90% / 15sec = 6% / sec
+  const progressIncrement = HANGING_BREAKPOINT / seconds;
+
+  useEffect(() => {
+    if (loading === LOADING_STATE.LOADING) {
+      // start the loader as soon as the user clicks the button, not after 1 second inside the setInterval
+      setProgress(progressIncrement);
+
+      interval = setInterval(
+        () =>
+          setProgress((prev) =>
+            prev < HANGING_BREAKPOINT
+              ? prev + progressIncrement
+              : HANGING_BREAKPOINT
+          ),
+        1000
+      );
+    }
+
+    if (loading === LOADING_STATE.COMPLETE) {
+      setProgress(100);
+
+      setTimeout(() => {
+        clearInterval(interval);
+        setLoading(LOADING_STATE.NOT_STARTED);
+        setProgress(0);
+      }, [SECONDS_SHOWN_AFTER_LOADED * 1000]);
+    }
+
+    return () => clearInterval(interval);
+  }, [loading]);
+
+  const isLoading =
+    loading === LOADING_STATE.LOADING ||
+    loading === LOADING_STATE.NINETY_PERCENT ||
+    loading === LOADING_STATE.COMPLETE;
+
+  return (
+    <div>
+      <div className="simulate-request">
+        <h3>Simulate Request</h3>
+        <label
+          title={isLoading ? "Disabled while loading" : ""}
+          className={isLoading ? "disabled" : ""}
+        >
+          Load Time (seconds):
+          <input
+            value={seconds}
+            type="number"
+            min="1"
+            onChange={(e) => setSeconds(e.target.value)}
+            disabled={isLoading}
+          />
+        </label>
+
+        <div>
+          <button
+            className="button start"
+            disabled={isLoading}
+            onClick={() => setLoading(LOADING_STATE.LOADING)}
+          >
+            {isLoading ? "loading..." : "start request"}
+          </button>
+
+          {isLoading && (
+            <button
+              className="button end"
+              onClick={() => setLoading(LOADING_STATE.COMPLETE)}
+              disabled={loading === LOADING_STATE.COMPLETE}
+            >
+              finish request
+            </button>
+          )}
+        </div>
+      </div>
+
+      {isLoading ? <ProgressBar progress={progress} /> : null}
+
+      {loading === LOADING_STATE.COMPLETE && (
+        <i>progress bar will disappear in 3 seconds</i>
+      )}
+    </div>
+  );
+};
+
+export default SimulateProgressBar;

--- a/src/components/SimulateProgress.js
+++ b/src/components/SimulateProgress.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import ProgressBar from "./ProgressBar";
 
-const INITIAL_LOADING_TIME = 1;
+const INITIAL_LOADING_TIME = 15;
 const HANGING_BREAKPOINT = 90;
 const SECONDS_SHOWN_AFTER_LOADED = 3;
 
@@ -48,7 +48,7 @@ const SimulateProgressBar = () => {
       // set progress to 0 after progress bar has faded out
       setTimeout(
         () => setProgress(0),
-        [SECONDS_SHOWN_AFTER_LOADED * 1000 + 1000]
+        [SECONDS_SHOWN_AFTER_LOADED * 1000 + 300]
       );
     }
 

--- a/src/components/SimulateProgress.scss
+++ b/src/components/SimulateProgress.scss
@@ -73,3 +73,8 @@ i {
   margin-top: 8px;
   color: $gray;
 }
+
+.fade-out {
+  opacity: 0;
+  transition: opacity 0.3s;
+}

--- a/src/components/SimulateProgress.scss
+++ b/src/components/SimulateProgress.scss
@@ -1,0 +1,73 @@
+.simulate-request {
+  padding: 24px;
+  margin-bottom: 48px;
+  box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+
+  label {
+    display: flex;
+    align-items: center;
+
+    &.disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  h3 {
+    margin-bottom: 8px;
+  }
+
+  input {
+    margin-left: 8px;
+    width: 36px;
+    padding: 8px;
+
+    border: solid 1px $gray-light;
+    border-radius: 4px;
+  }
+}
+
+.button {
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 48px;
+  transition: border-width 0.1s linear;
+
+  font-weight: 500;
+
+  width: 200px;
+  margin-top: 24px;
+  margin-right: 8px;
+  padding: 0.8rem 1.75rem;
+
+  text-transform: uppercase;
+
+  &:hover {
+    border-width: 2px;
+  }
+
+  &:active {
+    border-width: 3px;
+  }
+
+  &.start {
+    color: $green;
+    border-color: $green;
+  }
+
+  &.end {
+    color: $red;
+    border-color: $red;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+i {
+  display: inline-block;
+  margin-top: 8px;
+  color: $gray;
+}

--- a/src/components/SimulateProgress.scss
+++ b/src/components/SimulateProgress.scss
@@ -35,10 +35,12 @@
 
   font-weight: 500;
 
+  // border animation increases the height of the button, even with box-sizing: border box
+  // explicitly setting height keeps fixed and fixes layout thrash
+  height: 48px;
   width: 200px;
   margin-top: 24px;
   margin-right: 8px;
-  padding: 0.8rem 1.75rem;
 
   text-transform: uppercase;
 

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -1,11 +1,11 @@
 import React from "react";
 import Exercise from "../exercise/Exercise";
-import ProgressBar from "../components/ProgressBar";
+import SimulateProgressBar from "../components/SimulateProgress";
 
 const ProgressBarExercise = () => (
   <div className="progress-bar-exercise">
     <Exercise
-      solution={<ProgressBar progress={50} />}
+      solution={<SimulateProgressBar />}
       specsUrl="https://github.com/SpiffInc/spiff_react_exercises/issues/1"
       title="Progress Bar Exercise"
     />

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -1,22 +1,15 @@
 import React from "react";
 import Exercise from "../exercise/Exercise";
+import ProgressBar from "../components/ProgressBar";
 
-const ProgressBarExercise = () => {
-  return (
-    <div className="progress-bar-exercise">
-      <Exercise
-        solution={<Solution />}
-        specsUrl="https://github.com/SpiffInc/spiff_react_exercises/issues/1"
-        title="Progress Bar Exercise"
-      />
-    </div>
-  );
-};
+const ProgressBarExercise = () => (
+  <div className="progress-bar-exercise">
+    <Exercise
+      solution={<ProgressBar progress={50} />}
+      specsUrl="https://github.com/SpiffInc/spiff_react_exercises/issues/1"
+      title="Progress Bar Exercise"
+    />
+  </div>
+);
 
 export default ProgressBarExercise;
-
-// ----------------------------------------------------------------------------------
-
-const Solution = () => {
-  return <div>Add solution here</div>;
-};


### PR DESCRIPTION
### [Issue Link](https://github.com/SpiffInc/spiff_react_exercises/issues/1)

### Changes
- Add a progress bar component, 6px tall, with a background gradient that starts orange and ends red
- Simulate a request 15 seconds long that hangs at 90% completion
- Add a Start Request button that starts the progress
- Add a Finish Request button that finishes the progress
- Style according to design

### Submission Checklist:
- [x] I have tested this feature in Chrome, Safari, & Firefox

### Proof of completion
https://user-images.githubusercontent.com/16544821/222528511-48d1abe7-a711-415a-a433-744699a95436.mov